### PR TITLE
Fixed bug with release command

### DIFF
--- a/changes/cli.py
+++ b/changes/cli.py
@@ -62,7 +62,7 @@ log = logging.getLogger(__name__)
 
 def release():
     try:
-        if not arguments['--skip-changelog']:
+        if not config.arguments['--skip-changelog']:
             changelog()
         bump_version()
         run_tests()


### PR DESCRIPTION
Using release was giving this error

``` sh
(changes)kin@boxed-xawesome:~/Work/repositories/django-clickbank$ changes --tox -m --module-name=django-clickbank --debug django_clickbank release
DEBUG:changes.cli:arguments: {'--debug': True,
 '--dry-run': False,
 '--help': False,
 '--major': False,
 '--minor': True,
 '--module-name': 'django-clickbank',
 '--new-version': None,
 '--noinput': False,
 '--patch': False,
 '--pypi': None,
 '--skip-changelog': False,
 '--test-command': None,
 '--tox': True,
 '--version-prefix': None,
 '<app_name>': 'django_clickbank',
 'bump_version': False,
 'changelog': False,
 'install': False,
 'pypi': False,
 'release': True,
 'run_tests': False,
 'tag': False,
 'upload': False}
INFO:changes.probe:Checking project for changes requirements.
INFO:changes.probe:On Github? True
INFO:changes.probe:setup.py? True
INFO:changes.probe:requirements.txt? True
INFO:changes.probe:CHANGELOG.md? True
INFO:changes.probe:Has module metadata? True
INFO:changes.probe:Runs tests? True
What is the release version for "django_clickbank" [Default: 0.2.0]: 
ERROR:changes.cli:Error releasing
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/changes/cli.py", line 66, in release
    if not arguments['--skip-changelog']:
KeyError: '--skip-changelog'
```
