### PR TITLE
Support for other markup extensions for README files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ nosetests.xml
 *.iml
 .noseids
 .ropeproject
+
+# Virtual environments
+env/

--- a/README.md
+++ b/README.md
@@ -32,14 +32,15 @@ An application wanting to use `changes` must meet these requirements:
 * Publically hosted on [GitHub].
 * Has a `setup.py`.
 * Has a `requirements.txt`.
-* Has a `CHANGELOG.md`
+* Has a `CHANGELOG.md`.
+* Has a `README` with a [valid extension](https://github.com/github/.markup#markups)
 * `<app_name>/__init__.py` contains `__version__` and `__url__`.
 * Executing tests with `[py.test]` or `[tox`].
-* `<app_name>` is the package _and_ module name
+* `<app_name>` is the package _and_ module name.
 
 Install `changes`:
 
-    pip install changes
+    $ pip install changes
 
 Run the cli:
 

--- a/changes/probe.py
+++ b/changes/probe.py
@@ -1,5 +1,3 @@
-import re
-import os
 import logging
 
 from os.path import exists
@@ -17,11 +15,13 @@ TOOLS = ['git', 'diff', 'python']
 TEST_RUNNERS = ['pytest', 'nose', 'tox']
 
 README_EXTENSIONS = [
-    '.txt', '.md',
-    '.rst', '.wiki',
-    '.rdoc', '.org',
-    '.pod', ''
+    '.md', '.rst',
+    '.txt', ''
+    '.wiki', '.rdoc',
+    '.org', '.pod',
+    '.creole', '.textile'
 ]
+
 
 def report_and_raise(probe_name, probe_result, failure_msg):
     """Logs the probe result and raises on failure"""
@@ -69,19 +69,10 @@ def has_changelog():
 
 def has_readme():
     """README"""
-    readme = None
-    message = 'Create a README file'
-    for filename in os.listdir("."):
-        readme = re.match(r"README($|\.\w{2,})", filename, re.I)
-        if readme:
-            if readme.group(1) not in README_EXTENSIONS:
-                message += ' with a valid extension (or none)'
-                readme = None
-            break
     return report_and_raise(
         'README',
-        readme is not None,
-        message
+        any([exists('README{0}'.format(ext)) for ext in README_EXTENSIONS]),
+        "Create a (valid) README"
     )
 
 

--- a/changes/probe.py
+++ b/changes/probe.py
@@ -72,7 +72,7 @@ def has_readme():
     return report_and_raise(
         'README',
         any([exists('README{0}'.format(ext)) for ext in README_EXTENSIONS]),
-        "Create a (valid) README"
+        'Create a (valid) README'
     )
 
 

--- a/changes/probe.py
+++ b/changes/probe.py
@@ -75,8 +75,7 @@ def has_readme():
         readme = re.match(r"README($|\.\w{2,})", filename, re.I)
         if readme:
             if readme.group(1) not in README_EXTENSIONS:
-                message += ' with a valid extension '
-                message += '(%s)' % " | ".join(README_EXTENSIONS)
+                message += ' with a valid extension (or none)'
                 readme = None
             break
     return report_and_raise(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,12 +23,8 @@ context.initial_init_content = [
 ]
 
 def setup():
-
-    # If previous tests failed, the directory is still alive
-    # and causes problems with tests ('git remote already set')
-    teardown()
-
-    os.mkdir(context.module_name)
+    if not os.path.exists(module_name):
+        os.mkdir(context.module_name)
 
     with open(context.tmp_file, 'w') as init_file:
         init_file.write('\n'.join(context.initial_init_content))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -23,8 +23,12 @@ context.initial_init_content = [
 ]
 
 def setup():
-    if not os.path.exists(context.module_name):
-        os.mkdir(context.module_name)
+
+    # If previous tests failed, the directory is still alive
+    # and causes problems with tests ('git remote already set')
+    teardown()
+
+    os.mkdir(context.module_name)
 
     with open(context.tmp_file, 'w') as init_file:
         init_file.write('\n'.join(context.initial_init_content))
@@ -38,5 +42,5 @@ def setup():
 
 
 def teardown():
-    if os.path.exists(context.tmp_file):
-        shutil.rmtree(module_name)
+    if os.path.exists(context.module_name):
+        shutil.rmtree(context.module_name)

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -2,8 +2,8 @@ import os
 import glob
 import pytest
 
-from changes import probe
-from changes import exceptions
+from changes import probe, exceptions
+from plumbum import local
 
 from . import context, setup, teardown
 
@@ -22,29 +22,25 @@ def test_has_test_runner():
     assert probe.has_test_runner()
 
 def test_accepts_readme():
-	os.chdir(context.module_name)
-	for ext in probe.README_EXTENSIONS:
-		path = "README%s" % ext
-		with open(path, 'w'):
+	with local.cwd(local.cwd / context.module_name):
+		for ext in probe.README_EXTENSIONS:
+			path = "README{0}".format(ext)
+			open(path, 'w')
 			assert probe.has_readme()
 			os.remove(path)
-	os.chdir("..")
 
 def test_refuses_readme():
-	os.chdir(context.module_name)
-	for ext in [".py", ".doc", ".mp3"]:
-		path = "README%s" % ext
-		with open(path, 'w'):
+	with local.cwd(local.cwd / context.module_name):
+		for ext in [".py", ".doc", ".mp3"]:
+			path = "README{0}".format(ext)
+			open(path, 'w')
 			with pytest.raises(exceptions.ProbeException):
 				probe.has_readme()
 			os.remove(path)
-	os.chdir("..")
 
 def test_fails_for_missing_readme():
-	os.chdir(context.module_name)
-	for i in glob.glob("README*"):
-		os.remove(i)
-	with pytest.raises(exceptions.ProbeException):
-		probe.has_readme()
-	os.chdir("..")
-
+	with local.cwd(local.cwd / context.module_name):
+		for i in glob.glob("README*"):
+			os.remove(i)
+		with pytest.raises(exceptions.ProbeException):
+			probe.has_readme()

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -1,6 +1,11 @@
-from changes import probe
-from . import context, setup, teardown
+import os
+import glob
+import pytest
 
+from changes import probe
+from changes import exceptions
+
+from . import context, setup, teardown
 
 def test_probe_project():
     assert probe.probe_project(context)
@@ -13,6 +18,33 @@ def test_has_binary():
 def test_has_no_binary():
     assert not probe.has_binary('foo')
 
-
 def test_has_test_runner():
     assert probe.has_test_runner()
+
+def test_accepts_readme():
+	os.chdir(context.module_name)
+	for ext in probe.README_EXTENSIONS:
+		path = "README%s" % ext
+		with open(path, 'w'):
+			assert probe.has_readme()
+			os.remove(path)
+	os.chdir("..")
+
+def test_refuses_readme():
+	os.chdir(context.module_name)
+	for ext in [".py", ".doc", ".mp3"]:
+		path = "README%s" % ext
+		with open(path, 'w'):
+			with pytest.raises(exceptions.ProbeException):
+				probe.has_readme()
+			os.remove(path)
+	os.chdir("..")
+
+def test_fails_for_missing_readme():
+	os.chdir(context.module_name)
+	for i in glob.glob("README*"):
+		os.remove(i)
+	with pytest.raises(exceptions.ProbeException):
+		probe.has_readme()
+	os.chdir("..")
+

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -22,25 +22,25 @@ def test_has_test_runner():
     assert probe.has_test_runner()
 
 def test_accepts_readme():
-	with local.cwd(local.cwd / context.module_name):
-		for ext in probe.README_EXTENSIONS:
-			path = "README{0}".format(ext)
-			open(path, 'w')
-			assert probe.has_readme()
-			os.remove(path)
+    with local.cwd(local.cwd / context.module_name):
+        for ext in probe.README_EXTENSIONS:
+            path = 'README{0}'.format(ext)
+            open(path, 'w')
+            assert probe.has_readme()
+            os.remove(path)
 
 def test_refuses_readme():
-	with local.cwd(local.cwd / context.module_name):
-		for ext in [".py", ".doc", ".mp3"]:
-			path = "README{0}".format(ext)
-			open(path, 'w')
-			with pytest.raises(exceptions.ProbeException):
-				probe.has_readme()
-			os.remove(path)
+    with local.cwd(local.cwd / context.module_name):
+        for ext in ['.py', '.doc', '.mp3']:
+            path = 'README{0}'.format(ext)
+            open(path, 'w')
+            with pytest.raises(exceptions.ProbeException):
+                probe.has_readme()
+            os.remove(path)
 
 def test_fails_for_missing_readme():
-	with local.cwd(local.cwd / context.module_name):
-		for i in glob.glob("README*"):
-			os.remove(i)
-		with pytest.raises(exceptions.ProbeException):
-			probe.has_readme()
+    with local.cwd(local.cwd / context.module_name):
+        for i in glob.glob('README*'):
+            os.remove(i)
+        with pytest.raises(exceptions.ProbeException):
+            probe.has_readme()


### PR DESCRIPTION
I wanted to use changes for a Python project of mine which had a README.rst file rather than a README.md (as sphinx documentation makes use of restructuredText). This failed the probing done by changes. I implemented a way of checking a certain set of valid file extensions (e.g. .rst, .wiki, .rdoc -- [those that Github can render](https://github.com/github/markup#markups)) rather than only verifying whether or not README __.md__ exists. I added three tests in tests/test_probe.py to verify whether or not changes now

1. Accepts valid extensions such as .md, .rst, .pod ...
2. Refuses invalid extensions such as .doc, .py, .csv ...
3. Stops if no README is present at all

Case 3 gives an error message just stating that the client should add a README while case 2 states that the user should add a README with a valid extension.

Have a look and tell me if you think this solves a problem. If you'd like me to change anything about the code or style also let me know. And a last thing: if you like what I added, do you think that case 2) should display the allowed extensions? I had that first, but the line got too long so I removed it (for now). 

Regarding changes to tests/__init__.py: My tests failed at first and py.test doesn't seem to call teardown() upon failure? In any case the test_app directory was still there after test failures so now the test_app directory is removed at the start of tests (if existent).