### PR TITLE
Fix typo in CLI option descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Options:
   --new-version=<ver>        Specify version.
   -p --patch                 Patch-level version increment.
   -m --minor                 Minor-level version increment.
-  -M --major                 Minor-level version increment.
+  -M --major                 Major-level version increment.
 
   -h --help                  Show this screen.
 

--- a/changes/cli.py
+++ b/changes/cli.py
@@ -28,7 +28,7 @@ def print_version(ctx, param, value):
 @click.option('--requirements', default='requirements.txt', help='Requirements file name')
 @click.option('-p', '--patch', is_flag=True, help='Patch-level version increment.')
 @click.option('-m', '--minor', is_flag=True, help='Minor-level version increment.')
-@click.option('-M', '--major', is_flag=True, help='Minor-level version increment.')
+@click.option('-M', '--major', is_flag=True, help='Major-level version increment.')
 @click.option('--version-prefix', help='Specify a prefix for version number tags.')
 @click.option('--version', is_flag=True, callback=print_version,
               expose_value=False, is_eager=True)


### PR DESCRIPTION
I noticed that the major-level version increment option ("-M") in the CLI was described as being for "minor-level".